### PR TITLE
Add Tinder-like swipe interaction and mobile layout to interview cards

### DIFF
--- a/src/components/CardSession.css
+++ b/src/components/CardSession.css
@@ -3,6 +3,9 @@
   flex-direction: column;
   gap: 24px;
   align-items: center;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
 }
 
 .session-meta {
@@ -14,44 +17,79 @@
   flex-wrap: wrap;
 }
 
-.session-meta h2 {
+.session-info h2 {
   margin: 0 0 8px;
 }
 
-.session-meta p {
+.session-info p {
   margin: 0;
   color: #475569;
-  max-width: 560px;
+  max-width: 520px;
 }
 
 .session-actions {
   display: flex;
   align-items: center;
   gap: 12px;
+  margin-left: auto;
 }
 
-.session-actions button {
-  border: none;
-  padding: 8px 16px;
+.session-actions .ghost {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 8px 18px;
   border-radius: 999px;
-  background-color: #0f172a;
-  color: white;
+  background-color: #f8fafc;
+  color: #0f172a;
   font-weight: 600;
   cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.session-actions .ghost:hover {
+  background-color: #0f172a;
+  color: white;
+  border-color: #0f172a;
 }
 
 .progress {
   font-weight: 600;
   color: #0f172a;
+  min-width: 68px;
+  text-align: right;
 }
 
 .card-stage {
-  width: min(100%, 480px);
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 24px 16px 32px;
+}
+
+.card-stage-shadow {
+  position: absolute;
+  top: 0;
+  left: 20px;
+  right: 20px;
+  height: 82%;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.15), rgba(148, 163, 184, 0));
+  border-radius: 28px;
+  transform: translateY(18px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.card-stage > * {
+  position: relative;
+  z-index: 1;
 }
 
 .session-hint {
-  color: #64748b;
+  color: #475569;
   text-align: center;
+  font-size: 0.95rem;
 }
 
 .session-complete {
@@ -77,7 +115,7 @@
   background: #2563eb;
   color: white;
   font-weight: 600;
-  padding: 12px 24px;
+  padding: 12px 32px;
   border-radius: 999px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -91,4 +129,75 @@
 .next-button:not(:disabled):hover {
   transform: translateY(-1px);
   box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+}
+
+@media (max-width: 768px) {
+  .card-session {
+    gap: 20px;
+  }
+
+  .session-meta {
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
+    text-align: center;
+  }
+
+  .session-actions {
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+    margin-left: 0;
+    gap: 10px;
+  }
+
+  .session-actions .ghost {
+    width: 100%;
+  }
+
+  .progress {
+    width: 100%;
+    text-align: center;
+  }
+
+  .card-stage {
+    padding: 16px 0 24px;
+  }
+
+  .card-stage-shadow {
+    left: 12px;
+    right: 12px;
+  }
+
+  .session-hint {
+    font-size: 0.9rem;
+    color: #64748b;
+  }
+
+  .next-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .session-info h2 {
+    font-size: 1.4rem;
+  }
+
+  .session-info p {
+    font-size: 0.95rem;
+  }
+
+  .session-actions {
+    gap: 8px;
+  }
+
+  .session-actions .ghost {
+    padding: 10px 16px;
+  }
+
+  .card-stage-shadow {
+    left: 0;
+    right: 0;
+  }
 }

--- a/src/components/CardSession.jsx
+++ b/src/components/CardSession.jsx
@@ -51,21 +51,22 @@ export default function CardSession({ questions }) {
   return (
     <section className="card-session">
       <header className="session-meta">
-        <div>
-          <h2>Режим карточек</h2>
-          <p>Карточки не повторяются в рамках сессии. Нажмите на карточку, чтобы увидеть ответ.</p>
+        <div className="session-info">
+          <h2>Интервью-режим</h2>
+          <p>Фокусируйтесь на одном вопросе за раз. Переверните карточку, чтобы свериться с ответом.</p>
         </div>
         <div className="session-actions">
+          <button type="button" onClick={restart} className="ghost">
+            Перемешать
+          </button>
           <span className="progress" aria-live="polite">
             {progress}
           </span>
-          <button type="button" onClick={restart}>
-            Перемешать
-          </button>
         </div>
       </header>
 
       <div className="card-stage">
+        <div className="card-stage-shadow" aria-hidden="true" />
         <FlashCard
           key={activeQuestion?.id}
           question={activeQuestion}
@@ -83,7 +84,7 @@ export default function CardSession({ questions }) {
           </button>
         </div>
       ) : (
-        <div className="session-hint">Свайпните в сторону или нажмите кнопку ниже, чтобы перейти дальше.</div>
+        <div className="session-hint">Свайпните карту в сторону или воспользуйтесь кнопкой, чтобы перейти к следующему вопросу.</div>
       )}
 
       <button type="button" className="next-button" onClick={goNext} disabled={current >= order.length - 1}>

--- a/src/components/FlashCard.css
+++ b/src/components/FlashCard.css
@@ -1,6 +1,24 @@
+
 .flashcard-wrapper {
   perspective: 1200px;
   width: 100%;
+}
+
+.flashcard-motion {
+  position: relative;
+  width: 100%;
+  transition: transform 0.35s ease, opacity 0.35s ease;
+  touch-action: pan-y;
+  will-change: transform;
+}
+
+.flashcard-motion.dragging {
+  transition: none;
+  cursor: grabbing;
+}
+
+.flashcard-motion.exiting {
+  opacity: 0;
 }
 
 .flashcard {
@@ -55,8 +73,13 @@
 }
 
 @media (max-width: 600px) {
+  .flashcard-motion {
+    max-width: 360px;
+    margin: 0 auto;
+  }
+
   .flashcard {
-    height: 280px;
+    height: 300px;
   }
 
   .flashcard-face {

--- a/src/components/FlashCard.jsx
+++ b/src/components/FlashCard.jsx
@@ -1,32 +1,141 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import './FlashCard.css';
 
-const SWIPE_THRESHOLD = 50;
+const SWIPE_THRESHOLD = 120;
+const SWIPE_OUT_DURATION = 260;
 
 export default function FlashCard({ question, flipped, onFlip, onNext }) {
-  const [startX, setStartX] = useState(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const startPointRef = useRef(null);
+  const shouldBlockClick = useRef(false);
+  const exitTimerRef = useRef(null);
   const cardRef = useRef(null);
 
-  const handlePointerDown = (clientX) => {
-    setStartX(clientX);
+  useEffect(
+    () => () => {
+      if (exitTimerRef.current) {
+        clearTimeout(exitTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const resetState = () => {
+    startPointRef.current = null;
+    shouldBlockClick.current = false;
+    setOffset({ x: 0, y: 0 });
+    setIsDragging(false);
+    setIsExiting(false);
   };
 
-  const handlePointerUp = (clientX) => {
-    if (startX === null) return;
-    const delta = clientX - startX;
-    if (Math.abs(delta) > SWIPE_THRESHOLD) {
-      onNext();
+  const beginDrag = (clientX, clientY) => {
+    if (isExiting) return;
+    startPointRef.current = { x: clientX, y: clientY };
+    shouldBlockClick.current = false;
+    setIsDragging(true);
+  };
+
+  const updateDrag = (clientX, clientY) => {
+    if (!startPointRef.current || isExiting) {
+      return;
     }
-    setStartX(null);
+
+    const deltaX = clientX - startPointRef.current.x;
+    const deltaY = clientY - startPointRef.current.y;
+    const distance = Math.hypot(deltaX, deltaY);
+
+    if (distance > 6) {
+      shouldBlockClick.current = true;
+    }
+
+    setOffset({ x: deltaX, y: deltaY });
+  };
+
+  const completeDrag = (clientX, clientY) => {
+    if (!startPointRef.current || isExiting) {
+      resetState();
+      return;
+    }
+
+    const deltaX = clientX - startPointRef.current.x;
+    const deltaY = clientY - startPointRef.current.y;
+    const absX = Math.abs(deltaX);
+
+    if (absX > SWIPE_THRESHOLD) {
+      const direction = deltaX > 0 ? 1 : -1;
+      startPointRef.current = null;
+      triggerSwipe(direction, deltaY);
+    } else {
+      setIsDragging(false);
+      setOffset({ x: 0, y: 0 });
+      shouldBlockClick.current = false;
+      startPointRef.current = null;
+    }
+  };
+
+  const triggerSwipe = (direction, deltaY = 0) => {
+    if (isExiting) return;
+
+    const travel = (cardRef.current?.offsetWidth ?? 320) * 1.5 * direction;
+    setIsExiting(true);
+    setIsDragging(false);
+    shouldBlockClick.current = true;
+    setOffset({ x: travel, y: deltaY });
+
+    exitTimerRef.current = setTimeout(() => {
+      exitTimerRef.current = null;
+      onNext();
+      resetState();
+    }, SWIPE_OUT_DURATION);
   };
 
   const pointerProps = {
-    onMouseDown: (event) => handlePointerDown(event.clientX),
-    onMouseUp: (event) => handlePointerUp(event.clientX),
-    onMouseLeave: () => setStartX(null),
-    onTouchStart: (event) => handlePointerDown(event.touches[0].clientX),
-    onTouchEnd: (event) => handlePointerUp(event.changedTouches[0].clientX)
+    onMouseDown: (event) => beginDrag(event.clientX, event.clientY),
+    onMouseMove: (event) => {
+      if (isDragging) {
+        updateDrag(event.clientX, event.clientY);
+      }
+    },
+    onMouseUp: (event) => completeDrag(event.clientX, event.clientY),
+    onMouseLeave: () => {
+      if (!isDragging) return;
+      setIsDragging(false);
+      setOffset({ x: 0, y: 0 });
+      startPointRef.current = null;
+      shouldBlockClick.current = false;
+    },
+    onTouchStart: (event) => beginDrag(event.touches[0].clientX, event.touches[0].clientY),
+    onTouchMove: (event) => {
+      if (!isDragging) return;
+      const touch = event.touches[0];
+      if (touch) {
+        event.preventDefault();
+        updateDrag(touch.clientX, touch.clientY);
+      }
+    },
+    onTouchEnd: (event) => {
+      const touch = event.changedTouches[0];
+      if (touch) {
+        completeDrag(touch.clientX, touch.clientY);
+      }
+    }
+  };
+
+  const handleCardClick = () => {
+    if (isExiting) return;
+    if (shouldBlockClick.current) {
+      shouldBlockClick.current = false;
+      return;
+    }
+    onFlip();
+  };
+
+  const rotation = offset.x * 0.06;
+  const motionStyle = {
+    transform: `translate3d(${offset.x}px, ${offset.y}px, 0) rotate(${rotation}deg)`
   };
 
   if (!question) {
@@ -36,30 +145,35 @@ export default function FlashCard({ question, flipped, onFlip, onNext }) {
   return (
     <div className="flashcard-wrapper">
       <div
-        ref={cardRef}
-        className={`flashcard ${flipped ? 'flipped' : ''}`}
-        onClick={onFlip}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            onFlip();
-          }
-          if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
-            onNext();
-          }
-        }}
+        className={`flashcard-motion ${isDragging ? 'dragging' : ''} ${isExiting ? 'exiting' : ''}`.trim()}
+        style={motionStyle}
         {...pointerProps}
       >
-        <div className="flashcard-face flashcard-front">
-          <span className="badge">{question.topic}</span>
-          <p>{question.question}</p>
-          <span className="hint">Нажмите, чтобы увидеть ответ</span>
-        </div>
-        <div className="flashcard-face flashcard-back">
-          <p>{question.answer}</p>
-          <span className="hint">Свайпните, чтобы перейти дальше</span>
+        <div
+          ref={cardRef}
+          className={`flashcard ${flipped ? 'flipped' : ''}`}
+          role="button"
+          tabIndex={0}
+          onClick={handleCardClick}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              onFlip();
+            }
+            if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+              onNext();
+            }
+          }}
+        >
+          <div className="flashcard-face flashcard-front">
+            <span className="badge">{question.topic}</span>
+            <p>{question.question}</p>
+            <span className="hint">Нажмите, чтобы увидеть ответ</span>
+          </div>
+          <div className="flashcard-face flashcard-back">
+            <p>{question.answer}</p>
+            <span className="hint">Свайпните, чтобы перейти дальше</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Tinder-style swipe interaction with smooth exit animation for flashcards
- refresh the interview mode layout with simplified copy and a cleaner control bar
- update flashcard styling to support dragging transitions and responsive mobile sizing

## Testing
- npm install *(fails: registry access returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1170e68e8832e9ef74e3d062f2253