### PR TITLE
Hide session controls on mobile

### DIFF
--- a/src/components/CardSession.css
+++ b/src/components/CardSession.css
@@ -143,6 +143,10 @@
     text-align: center;
   }
 
+  .session-info p {
+    display: none;
+  }
+
   .session-actions {
     flex-direction: column;
     justify-content: center;
@@ -152,7 +156,7 @@
   }
 
   .session-actions .ghost {
-    width: 100%;
+    display: none;
   }
 
   .progress {
@@ -170,12 +174,11 @@
   }
 
   .session-hint {
-    font-size: 0.9rem;
-    color: #64748b;
+    display: none;
   }
 
   .next-button {
-    width: 100%;
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the shuffle and next-question buttons on screens 768px wide and smaller
- hide the swipe/focus description copy on mobile so the layout is cleaner

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68e118c831bc832ea64c4995374f055b