### PR TITLE
Add topic filters and swipe navigation to cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { QUESTIONS } from './data/questions.js';
 import QuestionList from './components/QuestionList.jsx';
 import CardSession from './components/CardSession.jsx';
@@ -11,7 +11,86 @@ const MODES = {
 
 export default function App() {
   const [mode, setMode] = useState(MODES.LIST);
+  const topics = useMemo(() => {
+    const unique = Array.from(new Set(QUESTIONS.map((item) => item.topic)));
+    return unique.sort((a, b) => a.localeCompare(b, 'ru', { sensitivity: 'base' }));
+  }, []);
+  const [selectedTopics, setSelectedTopics] = useState(() => [...topics]);
+  const [cardCount, setCardCount] = useState(() => Math.min(10, QUESTIONS.length));
+
   const total = useMemo(() => QUESTIONS.length, []);
+
+  const filteredQuestions = useMemo(() => {
+    const topicSet = new Set(selectedTopics);
+    return QUESTIONS.filter((question) => topicSet.has(question.topic));
+  }, [selectedTopics]);
+
+  const availableCount = filteredQuestions.length;
+
+  useEffect(() => {
+    if (availableCount === 0) {
+      setCardCount(0);
+      return;
+    }
+
+    setCardCount((prev) => {
+      if (!prev) {
+        return Math.min(10, availableCount);
+      }
+      return Math.min(prev, availableCount);
+    });
+  }, [availableCount]);
+
+  const sessionQuestions = useMemo(() => {
+    if (cardCount === 0) {
+      return [];
+    }
+    return filteredQuestions.slice(0, cardCount);
+  }, [filteredQuestions, cardCount]);
+
+  const sessionKey = useMemo(() => {
+    const normalizedTopics = [...selectedTopics].sort((a, b) => topics.indexOf(a) - topics.indexOf(b));
+    return `${normalizedTopics.join('|')}|${cardCount}`;
+  }, [selectedTopics, cardCount, topics]);
+
+  const selectionLabel = useMemo(() => {
+    if (selectedTopics.length === topics.length) {
+      return 'Все темы';
+    }
+    return selectedTopics.join(', ');
+  }, [selectedTopics, topics]);
+
+  const toggleTopic = (topic) => {
+    setSelectedTopics((prev) => {
+      const exists = prev.includes(topic);
+      if (exists) {
+        if (prev.length === 1) {
+          return prev;
+        }
+        return prev.filter((item) => item !== topic);
+      }
+      return [...prev, topic].sort((a, b) => topics.indexOf(a) - topics.indexOf(b));
+    });
+  };
+
+  const selectAllTopics = () => {
+    setSelectedTopics([...topics]);
+  };
+
+  const handleCardCountChange = (event) => {
+    if (availableCount === 0) {
+      setCardCount(0);
+      return;
+    }
+
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      return;
+    }
+
+    const clamped = Math.min(Math.max(value, 1), availableCount);
+    setCardCount(clamped);
+  };
 
   return (
     <div className="app-shell">
@@ -44,7 +123,57 @@ export default function App() {
         {mode === MODES.LIST ? (
           <QuestionList questions={QUESTIONS} />
         ) : (
-          <CardSession questions={QUESTIONS} key={QUESTIONS.length} />
+          <>
+            <section className="card-settings" aria-label="Настройки интервью-режима">
+              <div className="settings-group">
+                <h2>Темы для интервью</h2>
+                <div className="topic-options" role="group" aria-label="Выбор тем">
+                  {topics.map((topic) => (
+                    <label key={topic} className="topic-option">
+                      <input
+                        type="checkbox"
+                        checked={selectedTopics.includes(topic)}
+                        onChange={() => toggleTopic(topic)}
+                      />
+                      <span>{topic}</span>
+                    </label>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="select-all"
+                  onClick={selectAllTopics}
+                  disabled={selectedTopics.length === topics.length}
+                >
+                  Выбрать все темы
+                </button>
+              </div>
+
+              <div className="settings-group">
+                <label htmlFor="card-count">Количество карточек</label>
+                <div className="count-control">
+                  <input
+                    id="card-count"
+                    type="number"
+                    min="1"
+                    max={availableCount}
+                    value={availableCount === 0 ? 0 : cardCount}
+                    onChange={handleCardCountChange}
+                    disabled={availableCount === 0}
+                    inputMode="numeric"
+                  />
+                  <span className="count-hint">Доступно: {availableCount}</span>
+                </div>
+              </div>
+            </section>
+
+            <CardSession
+              key={sessionKey}
+              questions={sessionQuestions}
+              poolSize={availableCount}
+              selectionLabel={selectionLabel}
+            />
+          </>
         )}
       </main>
     </div>

--- a/src/components/CardSession.css
+++ b/src/components/CardSession.css
@@ -27,6 +27,12 @@
   max-width: 520px;
 }
 
+.session-summary {
+  margin-top: 8px;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
 .session-actions {
   display: flex;
   align-items: center;
@@ -92,6 +98,14 @@
   font-size: 0.95rem;
 }
 
+.session-empty {
+  background-color: rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  color: #334155;
+}
+
 .session-complete {
   display: flex;
   flex-direction: column;
@@ -110,6 +124,13 @@
   cursor: pointer;
 }
 
+.session-navigation {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.prev-button,
 .next-button {
   border: none;
   background: #2563eb;
@@ -119,6 +140,22 @@
   border-radius: 999px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.prev-button {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.prev-button:disabled {
+  background-color: #e2e8f0;
+  color: rgba(15, 23, 42, 0.4);
+  cursor: not-allowed;
+}
+
+.prev-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
 }
 
 .next-button:disabled {
@@ -177,8 +214,24 @@
     display: none;
   }
 
+  .session-navigation {
+    width: 100%;
+  }
+
+  .prev-button,
   .next-button {
-    display: none;
+    flex: 1;
+  }
+}
+
+@media (max-width: 420px) {
+  .session-navigation {
+    flex-direction: column;
+  }
+
+  .prev-button,
+  .next-button {
+    width: 100%;
   }
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -57,6 +57,94 @@
   min-height: 360px;
 }
 
+.card-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 20px;
+  padding: 24px;
+  background-color: #f8fafc;
+}
+
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-group h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.topic-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.topic-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background-color: white;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  cursor: pointer;
+  font-weight: 500;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.topic-option input {
+  accent-color: #2563eb;
+}
+
+.topic-option:hover {
+  border-color: #2563eb;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.15);
+}
+
+.select-all {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  padding: 0;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.select-all:disabled {
+  cursor: default;
+  color: rgba(37, 99, 235, 0.4);
+}
+
+.count-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.count-control input {
+  width: 96px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  font-size: 1rem;
+}
+
+.count-control input:disabled {
+  background-color: #e2e8f0;
+  cursor: not-allowed;
+}
+
+.count-hint {
+  color: #475569;
+}
+
 @media (max-width: 600px) {
   .app-shell {
     padding: 24px 16px 40px;
@@ -64,5 +152,13 @@
 
   .app-header h1 {
     font-size: 1.75rem;
+  }
+
+  .card-settings {
+    padding: 20px 16px;
+  }
+
+  .topic-options {
+    gap: 10px 10px;
   }
 }


### PR DESCRIPTION
## Summary
- add topic filters and adjustable card limits to the interview mode
- surface selection details in the session UI and handle empty filter states
- enable swiping left/right to move forward and backward with matching navigation controls

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e11a5c3ddc832e8c3d6e291580dfe8