### PR TITLE
Remove card navigation controls and prep GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_Store
+.vscode/

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "interview-cards",
-  "private": true,
+  "private": false,
   "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,6 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
+    "gh-pages": "^6.0.0",
     "vite": "^5.2.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,13 +54,6 @@ export default function App() {
     return `${normalizedTopics.join('|')}|${cardCount}`;
   }, [selectedTopics, cardCount, topics]);
 
-  const selectionLabel = useMemo(() => {
-    if (selectedTopics.length === topics.length) {
-      return 'Все темы';
-    }
-    return selectedTopics.join(', ');
-  }, [selectedTopics, topics]);
-
   const toggleTopic = (topic) => {
     setSelectedTopics((prev) => {
       const exists = prev.includes(topic);
@@ -196,8 +189,6 @@ export default function App() {
             <CardSession
               key={sessionKey}
               questions={sessionQuestions}
-              poolSize={availableCount}
-              selectionLabel={selectionLabel}
             />
           </>
         )}

--- a/src/components/CardSession.css
+++ b/src/components/CardSession.css
@@ -27,12 +27,6 @@
   max-width: 520px;
 }
 
-.session-summary {
-  margin-top: 8px;
-  font-size: 0.95rem;
-  color: #1e293b;
-}
-
 .session-actions {
   display: flex;
   align-items: center;
@@ -92,12 +86,6 @@
   z-index: 1;
 }
 
-.session-hint {
-  color: #475569;
-  text-align: center;
-  font-size: 0.95rem;
-}
-
 .session-empty {
   background-color: rgba(148, 163, 184, 0.16);
   border-radius: 16px;
@@ -124,50 +112,6 @@
   cursor: pointer;
 }
 
-.session-navigation {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-}
-
-.prev-button,
-.next-button {
-  border: none;
-  background: #2563eb;
-  color: white;
-  font-weight: 600;
-  padding: 12px 32px;
-  border-radius: 999px;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.prev-button {
-  background: #e2e8f0;
-  color: #0f172a;
-}
-
-.prev-button:disabled {
-  background-color: #e2e8f0;
-  color: rgba(15, 23, 42, 0.4);
-  cursor: not-allowed;
-}
-
-.prev-button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
-}
-
-.next-button:disabled {
-  background-color: #cbd5f5;
-  cursor: not-allowed;
-}
-
-.next-button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
-}
-
 @media (max-width: 768px) {
   .card-session {
     gap: 20px;
@@ -178,10 +122,6 @@
     gap: 16px;
     align-items: center;
     text-align: center;
-  }
-
-  .session-info p {
-    display: none;
   }
 
   .session-actions {
@@ -210,29 +150,6 @@
     right: 12px;
   }
 
-  .session-hint {
-    display: none;
-  }
-
-  .session-navigation {
-    width: 100%;
-  }
-
-  .prev-button,
-  .next-button {
-    flex: 1;
-  }
-}
-
-@media (max-width: 420px) {
-  .session-navigation {
-    flex-direction: column;
-  }
-
-  .prev-button,
-  .next-button {
-    width: 100%;
-  }
 }
 
 @media (max-width: 480px) {

--- a/src/components/CardSession.jsx
+++ b/src/components/CardSession.jsx
@@ -12,7 +12,7 @@ function shuffle(array) {
   return copy;
 }
 
-export default function CardSession({ questions, poolSize, selectionLabel }) {
+export default function CardSession({ questions }) {
   const [order, setOrder] = useState(() => shuffle(questions.map((_, idx) => idx)));
   const [current, setCurrent] = useState(0);
   const [flipped, setFlipped] = useState(false);
@@ -84,10 +84,6 @@ export default function CardSession({ questions, poolSize, selectionLabel }) {
       <header className="session-meta">
         <div className="session-info">
           <h2>Интервью-режим</h2>
-          <p>Фокусируйтесь на одном вопросе за раз. Переверните карточку, чтобы свериться с ответом.</p>
-          <p className="session-summary">
-            Темы: <strong>{selectionLabel}</strong>. Карточек в сессии: {questions.length} из {poolSize}.
-          </p>
         </div>
         <div className="session-actions">
           <button type="button" onClick={restart} className="ghost">
@@ -120,18 +116,7 @@ export default function CardSession({ questions, poolSize, selectionLabel }) {
             Начать заново
           </button>
         </div>
-      ) : (
-        <div className="session-hint">Свайпните карту влево, чтобы перейти к следующему вопросу, или вправо — чтобы вернуться назад.</div>
-      )}
-
-      <div className="session-navigation">
-        <button type="button" className="prev-button" onClick={goPrev} disabled={!canGoPrev}>
-          Предыдущий вопрос
-        </button>
-        <button type="button" className="next-button" onClick={goNext} disabled={!canGoNext}>
-          Следующий вопрос
-        </button>
-      </div>
+      ) : null}
     </section>
   );
 }
@@ -144,12 +129,5 @@ CardSession.propTypes = {
       question: PropTypes.string.isRequired,
       answer: PropTypes.string.isRequired
     })
-  ).isRequired,
-  poolSize: PropTypes.number,
-  selectionLabel: PropTypes.string
-};
-
-CardSession.defaultProps = {
-  poolSize: 0,
-  selectionLabel: '—'
+  ).isRequired
 };

--- a/src/components/FlashCard.jsx
+++ b/src/components/FlashCard.jsx
@@ -193,7 +193,7 @@ export default function FlashCard({
           </div>
           <div className="flashcard-face flashcard-back">
             <p>{question.answer}</p>
-            <span className="hint">Свайпните влево, чтобы перейти дальше, или вправо — чтобы вернуться</span>
+            <span className="hint">Нажмите, чтобы вернуться к вопросу</span>
           </div>
         </div>
       </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/interviewCards/',
   server: {
     host: '0.0.0.0',
     port: 5173


### PR DESCRIPTION
## Summary
- streamline the card session header by dropping redundant helper text and navigation buttons
- update flashcard helper copy to focus on tap interactions only
- add GitHub Pages deployment scripts, base path configuration, and ignore rules for build artifacts

## Testing
- npm install *(fails: 403 Forbidden from registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11de2e094832e9c8b8ae2546819f1