### PR TITLE
Optimize interview mode layout and card animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ export default function App() {
   }, []);
   const [selectedTopics, setSelectedTopics] = useState(() => [...topics]);
   const [cardCount, setCardCount] = useState(() => Math.min(10, QUESTIONS.length));
-  const [filtersVisible, setFiltersVisible] = useState(true);
+  const [filtersVisible, setFiltersVisible] = useState(false);
 
   const total = useMemo(() => QUESTIONS.length, []);
 
@@ -117,7 +117,7 @@ export default function App() {
         </nav>
       </header>
 
-      <main className="app-main">
+      <main className={`app-main${mode === MODES.CARDS ? ' cards-mode' : ''}`}>
         {mode === MODES.LIST ? (
           <QuestionList questions={QUESTIONS} />
         ) : (

--- a/src/components/CardSession.css
+++ b/src/components/CardSession.css
@@ -1,11 +1,12 @@
 .card-session {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
   align-items: center;
   width: 100%;
   max-width: 640px;
   margin: 0 auto;
+  flex: 1;
 }
 
 .session-meta {
@@ -65,7 +66,7 @@
   justify-content: center;
   max-width: 520px;
   margin: 0 auto;
-  padding: 24px 16px 32px;
+  padding: 20px 12px 28px;
 }
 
 .card-stage-shadow {
@@ -114,7 +115,7 @@
 
 @media (max-width: 768px) {
   .card-session {
-    gap: 20px;
+    gap: 18px;
   }
 
   .session-meta {
@@ -142,7 +143,7 @@
   }
 
   .card-stage {
-    padding: 16px 0 24px;
+    padding: 16px 0 22px;
   }
 
   .card-stage-shadow {
@@ -167,6 +168,10 @@
 
   .session-actions .ghost {
     padding: 10px 16px;
+  }
+
+  .card-stage {
+    padding: 12px 0 16px;
   }
 
   .card-stage-shadow {

--- a/src/components/FlashCard.css
+++ b/src/components/FlashCard.css
@@ -2,6 +2,23 @@
 .flashcard-wrapper {
   perspective: 1200px;
   width: 100%;
+  transform: translateZ(0);
+}
+
+.flashcard-wrapper.entering {
+  animation: flashcardEnter 0.28s cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+@keyframes flashcardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .flashcard-motion {
@@ -79,7 +96,7 @@
   }
 
   .flashcard {
-    height: 300px;
+    height: 288px;
   }
 
   .flashcard-face {
@@ -88,5 +105,20 @@
 
   .flashcard p {
     font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .flashcard {
+    height: 260px;
+  }
+
+  .flashcard-face {
+    padding: 20px;
+    gap: 14px;
+  }
+
+  .flashcard p {
+    font-size: 0.98rem;
   }
 }

--- a/src/components/FlashCard.jsx
+++ b/src/components/FlashCard.jsx
@@ -4,6 +4,7 @@ import './FlashCard.css';
 
 const SWIPE_THRESHOLD = 120;
 const SWIPE_OUT_DURATION = 260;
+const SWIPE_IN_DURATION = 280;
 
 export default function FlashCard({
   question,
@@ -16,6 +17,7 @@ export default function FlashCard({
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const [isExiting, setIsExiting] = useState(false);
+  const [isEntering, setIsEntering] = useState(true);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const startPointRef = useRef(null);
   const shouldBlockClick = useRef(false);
@@ -30,6 +32,21 @@ export default function FlashCard({
     };
   }, []);
 
+  useEffect(() => {
+    if (!question) {
+      return undefined;
+    }
+
+    setIsEntering(true);
+    const timer = setTimeout(() => {
+      setIsEntering(false);
+    }, SWIPE_IN_DURATION);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [question?.id]);
+
   const resetState = () => {
     startPointRef.current = null;
     shouldBlockClick.current = false;
@@ -43,6 +60,7 @@ export default function FlashCard({
     startPointRef.current = { x: clientX, y: clientY };
     shouldBlockClick.current = false;
     setIsDragging(true);
+    setIsEntering(false);
   };
 
   const updateDrag = (clientX, clientY) => {
@@ -161,7 +179,7 @@ export default function FlashCard({
   }
 
   return (
-    <div className="flashcard-wrapper">
+    <div className={`flashcard-wrapper${isEntering ? ' entering' : ''}`}>
       <div
         className={`flashcard-motion ${isDragging ? 'dragging' : ''} ${isExiting ? 'exiting' : ''}`.trim()}
         style={motionStyle}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -57,6 +57,12 @@
   min-height: 360px;
 }
 
+.app-main.cards-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .card-settings {
   display: flex;
   flex-direction: column;
@@ -70,6 +76,7 @@
 
 .card-settings.collapsed {
   gap: 12px;
+  padding: 20px 24px 16px;
 }
 
 .settings-header {
@@ -194,15 +201,29 @@
 
 @media (max-width: 600px) {
   .app-shell {
-    padding: 24px 16px 40px;
+    padding: 18px 16px 28px;
+    gap: 24px;
   }
 
   .app-header h1 {
     font-size: 1.75rem;
   }
 
+  .mode-switcher button {
+    padding: 6px 14px;
+  }
+
+  .app-main.cards-mode {
+    gap: 16px;
+  }
+
   .card-settings {
-    padding: 20px 16px;
+    padding: 18px 16px;
+    gap: 16px;
+  }
+
+  .card-settings.collapsed {
+    padding: 14px 16px 12px;
   }
 
   .topic-options {


### PR DESCRIPTION
## Summary
- hide interview-mode filters by default and apply cards-mode specific layout spacing
- tighten card session spacing and responsive sizing so mobile screens fit without scrolling
- add swipe-in animation for flashcards alongside updated mobile card dimensions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11fb3cce8832e97a10777b3126224